### PR TITLE
Expand tilde in IdentityFile (fixes #1)

### DIFF
--- a/lib/sshconf.js
+++ b/lib/sshconf.js
@@ -32,6 +32,12 @@ module.exports = {
       }
 
       host['Host'].forEach(function(hostString) {
+        if (typeof host['IdentityFile'] === 'string') {
+          var home = os.homedir();
+          var identityFile = host['IdentityFile'];
+          host['IdentityFile'] = home ? identityFile.replace(/^~($|\/|\\)/, home + '$1') : identityFile;
+        }
+
         hosts[hostString] = Object.assign({}, hosts[hostString], host);
       });
     });


### PR DESCRIPTION
This PR resolves tilde character at the beginning of an `IdentityFile` path to the user’s home directory if one exists.